### PR TITLE
add reasonable default to command

### DIFF
--- a/flows/podman/podman_flows.py
+++ b/flows/podman/podman_flows.py
@@ -31,7 +31,7 @@ def setup_logger():
 async def launch_podman_flow(
     image_name: str,
     image_tag: str,
-    command: str = "python /app/work/config/params.yaml",
+    command: str = "python src/train.py /app/work/config/params.yaml",
     params: dict = {},
     volumes: list = [],
     network: str = "",


### PR DESCRIPTION
Since we expect the command to likely be the same, we can provide it as a reasonable default, which shows up in the UI and can be overridden. 

I know that this default currently only applies to the dlsia container, but it seems like the mechanism that we're building here is reasonable for future containers working with podman.