### PR TITLE
Adding Slurm jobs

### DIFF
--- a/flows/conda/schema.py
+++ b/flows/conda/schema.py
@@ -9,3 +9,6 @@ class CondaParams(BaseModel):
         description="Python file to run", default="src/train.py"
     )
     params: Optional[dict] = {}
+    
+    class Config:
+        extra = "forbid"

--- a/flows/parent_flow.py
+++ b/flows/parent_flow.py
@@ -24,7 +24,7 @@ async def launch_parent_flow(
 ):
     prefect_logger = get_run_logger()
 
-    flow_run_id = None
+    flow_run_id = ""
     for params in params_list:
         if flow_type == FlowType.podman:
             flow_run_id = await launch_podman(

--- a/flows/parent_flow.py
+++ b/flows/parent_flow.py
@@ -7,21 +7,24 @@ from flows.conda.conda_flows import launch_conda
 from flows.conda.schema import CondaParams
 from flows.podman.podman_flows import launch_podman
 from flows.podman.schema import PodmanParams
+from flows.slurm.schema import SlurmParams
+from flows.slurm.slurm_flows import launch_slurm
 
 
 class FlowType(str, Enum):
     podman = "podman"
     conda = "conda"
+    slurm = "slurm"
 
 
 @flow(name="Parent flow")
 async def launch_parent_flow(
     flow_type: FlowType,
-    params_list: list[Union[PodmanParams, CondaParams]],
+    params_list: list[Union[PodmanParams, CondaParams, SlurmParams]],
 ):
     prefect_logger = get_run_logger()
 
-    flow_run_id = ""
+    flow_run_id = None
     for params in params_list:
         if flow_type == FlowType.podman:
             flow_run_id = await launch_podman(
@@ -30,6 +33,10 @@ async def launch_parent_flow(
         elif flow_type == FlowType.conda:
             flow_run_id = await launch_conda(
                 conda_params=params, prev_flow_run_id=flow_run_id
+            )
+        elif flow_type == FlowType.slurm:
+            flow_run_id = await launch_slurm(
+                slurm_params=params, prev_flow_run_id=flow_run_id
             )
         else:
             prefect_logger.error("Flow type not supported")

--- a/flows/slurm/run_slurm.sh
+++ b/flows/slurm/run_slurm.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 # Check if all arguments are provided
-if [ $# -ne 8 ]; then
-    echo "Usage: $0 <job_name> <num_nodes> <partitions> <reservations> <max_time> <conda_env> <python_file> <yaml_file>"
-    exit 1
+if [ $# -ne 10 ]; then
+    echo "Usage: $0 <job_name> <num_nodes> <partitions> <reservations> <max_time> <conda_env> <forward_ports> <submission_ssh_key> <python_file> <yaml_file>"
 fi
 
 # Assign arguments to variables
@@ -13,8 +12,10 @@ partitions=$3
 reservations=$4
 max_time=$5
 conda_env=$6
-python_file=$7
-yaml_file=$8
+forward_ports=$7
+submission_ssh_key=$8
+python_file=$9
+yaml_file=$10
 
 # Create a temporary Slurm batch script
 BATCH_SCRIPT=$(mktemp ./tmp_script.XXXXXX)
@@ -22,14 +23,14 @@ BATCH_SCRIPT=$(mktemp ./tmp_script.XXXXXX)
 # Write the Slurm batch script
 echo "#!/bin/bash" > $BATCH_SCRIPT
 
-if [ "$partitions" = "" ]
+if [ -z "$partitions" ]
 then
     echo "Partitions is unset or empty"
 else
     echo "#SBATCH --partition=$partitions" >> $BATCH_SCRIPT
 fi
 
-if [ "$reservations" = "" ]
+if [ -z "$reservations" ]
 then
     echo "Reservations is unset or empty"
 else
@@ -44,11 +45,31 @@ echo "source /etc/profile.d/modules.sh" >> $BATCH_SCRIPT
 echo "module load maxwell mamba" >> $BATCH_SCRIPT
 echo ". mamba-init" >> $BATCH_SCRIPT
 echo "mamba activate $conda_env" >> $BATCH_SCRIPT
+if [ ! -z "$forward_ports" ]; then
+    echo -n "ssh " >> $BATCH_SCRIPT
+    # If an ssh key was specified, pass it as an additional argument
+    if [ ! -z "$submission_ssh_key" ]; then
+        echo -n "-i $submission_ssh_key " >> $BATCH_SCRIPT
+    fi
+    # Loop over forward_ports and append each forwarding rule
+    IFS=',' read -ra ADDR <<< "$forward_ports"
+    for port_pair in "${ADDR[@]}"; do
+        echo $port_pair
+        local_port=${port_pair%:*}
+        remote_port=${port_pair#*:}
+        echo -n "-L $local_port:localhost:$remote_port " >> $BATCH_SCRIPT
+    done
+    # -N tells SSH to not execute a remote command
+    echo -n "-N " >> $BATCH_SCRIPT
+    # Finally, specify host to tunnel to
+    # & at the end of the line makes the command run in the background
+    echo -n "$USER@$JOB_SUBMISSION_HOST &" >> $BATCH_SCRIPT
+fi
 echo "srun python $python_file $yaml_file" >> $BATCH_SCRIPT
 echo $BATCH_SCRIPT
 
 # Submit the Slurm batch script and capture the job ID
-JOB_ID=$(sbatch $BATCH_SCRIPT | awk '{print $4}')
+JOB_ID=$(sbatch --export=ALL,JOB_SUBMISSION_HOST=$(hostname),JOB_SUBMISSION_SSH_KEY="$submission_ssh_key"
 
 # Print the job ID
 echo "Submitted job with ID $JOB_ID"
@@ -65,10 +86,10 @@ while true; do
     elif [[ $JOB_STATUS == *"FAILED"* ]]; then
         # If the job has failed, print an error message and exit with a non-zero status
         echo "Job $JOB_ID has failed" >&2
-        
+
         # Remove the temporary Slurm batch script
         rm $BATCH_SCRIPT
-        
+
         exit 1
     else
         # If the job is neither completed nor failed, print its status

--- a/flows/slurm/run_slurm.sh
+++ b/flows/slurm/run_slurm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Check if all arguments are provided
-if [ $# -ne 5 ]; then
+if [ $# -ne 8 ]; then
     echo "Usage: $0 <job_name> <num_nodes> <partitions> <reservations> <max_time> <conda_env> <python_file> <yaml_file>"
     exit 1
 fi

--- a/flows/slurm/run_slurm.sh
+++ b/flows/slurm/run_slurm.sh
@@ -69,7 +69,7 @@ echo "srun python $python_file $yaml_file" >> $BATCH_SCRIPT
 echo $BATCH_SCRIPT
 
 # Submit the Slurm batch script and capture the job ID
-JOB_ID=$(sbatch --export=ALL,JOB_SUBMISSION_HOST=$(hostname),JOB_SUBMISSION_SSH_KEY="$submission_ssh_key"
+JOB_ID=$(sbatch --export=ALL,JOB_SUBMISSION_HOST=$(hostname),JOB_SUBMISSION_SSH_KEY="$submission_ssh_key" $BATCH_SCRIPT | awk '{print $4}')
 
 # Print the job ID
 echo "Submitted job with ID $JOB_ID"

--- a/flows/slurm/run_slurm.sh
+++ b/flows/slurm/run_slurm.sh
@@ -21,8 +21,21 @@ BATCH_SCRIPT=$(mktemp)
 
 # Write the Slurm batch script
 echo "#!/bin/bash" > $BATCH_SCRIPT
-echo "#SBATCH --partition=$partitions" >> $BATCH_SCRIPT
-echo "#SBATCH --reservation=$reservations" >> $BATCH_SCRIPT
+
+if [ "$partitions" = "" ]
+then
+    echo "Partitions is unset or empty"
+else
+    echo "#SBATCH --partition=$partitions" >> $BATCH_SCRIPT
+fi
+
+if [ "$reservations" = "" ]
+then
+    echo "Reservations is unset or empty"
+else
+    echo "#SBATCH --reservation=$reservations" >> $BATCH_SCRIPT
+fi
+
 echo "#SBATCH --nodes=$num_nodes" >> $BATCH_SCRIPT
 echo "#SBATCH --job-name=$job_name" >> $BATCH_SCRIPT
 echo "#SBATCH --time=$max_time" >> $BATCH_SCRIPT

--- a/flows/slurm/run_slurm.sh
+++ b/flows/slurm/run_slurm.sh
@@ -37,6 +37,8 @@ else
     echo "#SBATCH --reservation=$reservations" >> $BATCH_SCRIPT
 fi
 
+JOB_SUBMISSION_HOST=$(hostname)
+
 echo "#SBATCH --nodes=$num_nodes" >> $BATCH_SCRIPT
 echo "#SBATCH --job-name=$job_name" >> $BATCH_SCRIPT
 echo "#SBATCH --time=$max_time" >> $BATCH_SCRIPT
@@ -63,13 +65,13 @@ if [ ! -z "$forward_ports" ]; then
     echo -n "-N " >> $BATCH_SCRIPT
     # Finally, specify host to tunnel to
     # & at the end of the line makes the command run in the background
-    echo -n "$USER@$JOB_SUBMISSION_HOST &" >> $BATCH_SCRIPT
+    echo "$USER@$JOB_SUBMISSION_HOST &" >> $BATCH_SCRIPT
 fi
 echo "srun python $python_file $yaml_file" >> $BATCH_SCRIPT
 echo $BATCH_SCRIPT
 
 # Submit the Slurm batch script and capture the job ID
-JOB_ID=$(sbatch --export=ALL,JOB_SUBMISSION_HOST=$(hostname),JOB_SUBMISSION_SSH_KEY="$submission_ssh_key" $BATCH_SCRIPT | awk '{print $4}')
+JOB_ID=$(sbatch --export=ALL,JOB_SUBMISSION_HOST=$JOB_SUBMISSION_HOST,JOB_SUBMISSION_SSH_KEY="$submission_ssh_key" $BATCH_SCRIPT | awk '{print $4}')
 
 # Print the job ID
 echo "Submitted job with ID $JOB_ID"

--- a/flows/slurm/run_slurm.sh
+++ b/flows/slurm/run_slurm.sh
@@ -15,7 +15,7 @@ conda_env=$6
 forward_ports=$7
 submission_ssh_key=$8
 python_file=$9
-yaml_file=$10
+yaml_file=${10}
 
 # Create a temporary Slurm batch script
 BATCH_SCRIPT=$(mktemp ./tmp_script.XXXXXX)

--- a/flows/slurm/run_slurm.sh
+++ b/flows/slurm/run_slurm.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Check if all arguments are provided
+if [ $# -ne 5 ]; then
+    echo "Usage: $0 <job_name> <num_nodes> <partitions> <reservations> <max_time> <conda_env> <python_file> <yaml_file>"
+    exit 1
+fi
+
+# Assign arguments to variables
+job_name=$1
+num_nodes=$2
+partitions=$3
+reservations=$4
+max_time=$5
+conda_env=$6
+python_file=$7
+yaml_file=$8
+
+# Create a temporary Slurm batch script
+BATCH_SCRIPT=$(mktemp)
+
+# Write the Slurm batch script
+echo "#!/bin/bash" > $BATCH_SCRIPT
+echo "#SBATCH --partition=$partitions" >> $BATCH_SCRIPT
+echo "#SBATCH --reservation=$reservations" >> $BATCH_SCRIPT
+echo "#SBATCH --nodes=$num_nodes" >> $BATCH_SCRIPT
+echo "#SBATCH --job-name=$job_name" >> $BATCH_SCRIPT
+echo "#SBATCH --time=$max_time" >> $BATCH_SCRIPT
+echo "module load python" >> $BATCH_SCRIPT
+echo "conda activate $conda_env" >> $BATCH_SCRIPT
+echo "srun python $python_file $yaml_file" >> $BATCH_SCRIPT
+
+# Submit the Slurm batch script and capture the job ID
+JOB_ID=$(sbatch $BATCH_SCRIPT | awk '{print $4}')
+
+# Remove the temporary Slurm batch script
+rm $BATCH_SCRIPT
+
+# Print the job ID
+echo "Submitted job with ID $JOB_ID"
+
+# Track the progress of the job
+while true; do
+    # Get the job status
+    JOB_STATUS=$(sacct -j $JOB_ID --format=State --noheader | head -1 | awk '{print $1}')
+
+    if [[ $JOB_STATUS == *"COMPLETED"* ]]; then
+        # If the job is completed, break the loop
+        echo "Job $JOB_ID has completed"
+        break
+    elif [[ $JOB_STATUS == *"FAILED"* ]]; then
+        # If the job has failed, print an error message and exit with a non-zero status
+        echo "Job $JOB_ID has failed" >&2
+        exit 1
+    else
+        # If the job is neither completed nor failed, print its status
+        echo "Job $JOB_ID is $JOB_STATUS"
+    fi
+    sleep 10
+done

--- a/flows/slurm/schema.py
+++ b/flows/slurm/schema.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, StringConstraints
+from typing_extensions import Annotated
+
+
+class SlurmParams(BaseModel):
+    job_name: str
+    num_nodes: int
+    partitions: Optional[List[str]] = None
+    reservations: Optional[List[str]] = None
+    max_time: Annotated[
+        str,
+        StringConstraints(
+            strip_whitespace=True,
+            to_upper=True,
+            pattern=r"^([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$",
+        ),
+    ]
+    conda_env_name: str
+    python_file_name: str = Field(
+        description="Python file to run", default="src/train.py"
+    )
+    params: Optional[dict] = {}

--- a/flows/slurm/schema.py
+++ b/flows/slurm/schema.py
@@ -1,22 +1,14 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, StringConstraints
-from typing_extensions import Annotated
+from pydantic import BaseModel, Field
 
 
 class SlurmParams(BaseModel):
     job_name: str
     num_nodes: int
-    partitions: Optional[List[str]] = None
-    reservations: Optional[List[str]] = None
-    max_time: Annotated[
-        str,
-        StringConstraints(
-            strip_whitespace=True,
-            to_upper=True,
-            pattern=r"^([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$",
-        ),
-    ]
+    partitions: Optional[List[str]] = []
+    reservations: Optional[List[str]] = []
+    max_time: str = Field(regex=r"^([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$")
     conda_env_name: str
     python_file_name: str = Field(
         description="Python file to run", default="src/train.py"

--- a/flows/slurm/schema.py
+++ b/flows/slurm/schema.py
@@ -8,7 +8,7 @@ class SlurmParams(BaseModel):
     num_nodes: int
     partitions: Optional[List[str]] = []
     reservations: Optional[List[str]] = []
-    max_time: str = Field(regex=r"^([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$")
+    max_time: str = Field(pattern=r"^([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$")
     conda_env_name: str
     python_file_name: str = Field(
         description="Python file to run", default="src/train.py"

--- a/flows/slurm/schema.py
+++ b/flows/slurm/schema.py
@@ -10,6 +10,9 @@ class SlurmParams(BaseModel):
     reservations: Optional[List[str]] = []
     max_time: str = Field(pattern=r"^([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$")
     conda_env_name: str
+    # TODO: Enforce port pair format
+    forward_ports: Optional[List[str]] = []
+    submission_ssh_key: Optional[str] = None
     python_file_name: str = Field(
         description="Python file to run", default="src/train.py"
     )

--- a/flows/slurm/slurm_flows.py
+++ b/flows/slurm/slurm_flows.py
@@ -55,7 +55,7 @@ async def launch_slurm(
         cmd = [
             "flows/slurm/run_slurm.sh",
             slurm_params.job_name,
-            slurm_params.num_nodes,
+            str(slurm_params.num_nodes),
             ",".join(slurm_params.partitions),
             ",".join(slurm_params.reservations),
             slurm_params.max_time,

--- a/flows/slurm/slurm_flows.py
+++ b/flows/slurm/slurm_flows.py
@@ -49,7 +49,7 @@ async def launch_slurm(
     slurm_params.params["io_parameters"]["uid_save"] = current_flow_run_id
 
     # Create temporary file for parameters
-    with tempfile.NamedTemporaryFile(mode="w+t") as temp_file:
+    with tempfile.NamedTemporaryFile(mode="w+t", dir=".") as temp_file:
         yaml.dump(slurm_params.params, temp_file)
         # Define conda command
         cmd = [
@@ -67,7 +67,7 @@ async def launch_slurm(
         process = await run_process(cmd, stream_output=True)
 
     if process.returncode != 0:
-        return Failed(message="Podman command failed")
+        return Failed(message="Slurm command failed")
     pass
 
     return current_flow_run_id

--- a/flows/slurm/slurm_flows.py
+++ b/flows/slurm/slurm_flows.py
@@ -1,1 +1,73 @@
-# TODO
+# TODO: Check pyslurm: https://github.com/PySlurm/pyslurm/tree/main
+import sys
+import tempfile
+
+import yaml
+from prefect import context, flow, get_run_logger
+from prefect.states import Failed
+from prefect.utilities.processutils import run_process
+
+from flows.slurm.schema import SlurmParams
+
+
+class Logger:
+    def __init__(self, logger, level="info"):
+        self.logger = getattr(logger, level)
+
+    def write(self, message):
+        if message != "\n":
+            self.logger(message)
+
+    def flush(self):
+        pass
+
+
+def setup_logger():
+    """
+    Adopt stdout and stderr to prefect logger
+    """
+    prefect_logger = get_run_logger()
+    sys.stdout = Logger(prefect_logger, level="info")
+    sys.stderr = Logger(prefect_logger, level="error")
+    return prefect_logger
+
+
+@flow(name="launch_slurm")
+async def launch_slurm(
+    slurm_params: SlurmParams,
+    prev_flow_run_id: str = None,
+):
+    logger = setup_logger()
+
+    if prev_flow_run_id:
+        # Append the previous flow run id to parameters if provided
+        slurm_params.params["io_parameters"]["uid_retrieve"] = prev_flow_run_id
+
+    current_flow_run_id = str(context.get_run_context().flow_run.id)
+
+    # Append current flow run id
+    slurm_params.params["io_parameters"]["uid_save"] = current_flow_run_id
+
+    # Create temporary file for parameters
+    with tempfile.NamedTemporaryFile(mode="w+t") as temp_file:
+        yaml.dump(slurm_params.params, temp_file)
+        # Define conda command
+        cmd = [
+            "flows/slurm/run_slurm.sh",
+            slurm_params.job_name,
+            slurm_params.num_nodes,
+            ",".join(slurm_params.partitions),
+            ",".join(slurm_params.reservations),
+            slurm_params.max_time,
+            slurm_params.conda_env_name,
+            slurm_params.python_file_name,
+            temp_file.name,
+        ]
+        logger.info(f"Launching with command: {cmd}")
+        process = await run_process(cmd, stream_output=True)
+
+    if process.returncode != 0:
+        return Failed(message="Podman command failed")
+    pass
+
+    return current_flow_run_id

--- a/flows/slurm/slurm_flows.py
+++ b/flows/slurm/slurm_flows.py
@@ -60,6 +60,8 @@ async def launch_slurm(
             ",".join(slurm_params.reservations),
             slurm_params.max_time,
             slurm_params.conda_env_name,
+            ",".join(slurm_params.forward_ports),
+            slurm_params.submission_ssh_key,
             slurm_params.python_file_name,
             temp_file.name,
         ]

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -34,8 +34,20 @@ deployments:
     job_variables: {}
   schedule:
   is_schedule_active: true
-- name: launch_parent_flow
+- name: launch_slurm
   version: 0.0.1
+  tags: []
+  description: Launch slurm job
+  entrypoint: flows/slurm/slurm_flows.py:launch_slurm
+  parameters: {}
+  work_pool:
+    name: mlex_pool
+    work_queue_name: default-queue
+    job_variables: {}
+  schedule:
+  is_schedule_active: true
+- name: launch_parent_flow
+  version: 0.0.2
   tags: []
   description: Launch parent flow
   entrypoint: flows/parent_flow.py:launch_parent_flow


### PR DESCRIPTION
This PR adds the option to run slurm flows at [Maxwell](https://wiki.desy.de/confluence/MXW/Documentation_206801086.html). In addition to standard slurm parameters, this PR adds the option to set up port forwarding when the ML jobs require access to MLEx services located in a different node (e.g. tiled)